### PR TITLE
Align Batched Controller with Main

### DIFF
--- a/quadruped_pympc/controllers/gradient/collaborative/centroidal_nmpc_collaborative.py
+++ b/quadruped_pympc/controllers/gradient/collaborative/centroidal_nmpc_collaborative.py
@@ -2,7 +2,8 @@
 
 # Authors: Giulio Turrisi - 
 
-from acados_template import AcadosOcp, AcadosOcpSolver, ACADOS_INFTY
+from acados_template import AcadosOcp, AcadosOcpSolver
+ACADOS_INFTY = 1000
 from .centroidal_model_collaborative import Centroidal_Model_Collaborative
 import numpy as np
 import scipy.linalg

--- a/quadruped_pympc/controllers/gradient/input_rates/centroidal_nmpc_input_rates.py
+++ b/quadruped_pympc/controllers/gradient/input_rates/centroidal_nmpc_input_rates.py
@@ -9,7 +9,8 @@ import casadi as cs
 import copy
 from typing import Tuple
 # TODO: Check acados installation and trow error + instructions if needed ->  pip install quadruped_pympc[acados]
-from acados_template import AcadosOcp, AcadosOcpSolver, ACADOS_INFTY
+from acados_template import AcadosOcp, AcadosOcpSolver
+ACADOS_INFTY = ACADOS_INFTY = 1000
 from quadruped_pympc import config
 from .centroidal_model_input_rates import Centroidal_Model_InputRates
 

--- a/quadruped_pympc/controllers/gradient/lyapunov/centroidal_nmpc_lyapunov.py
+++ b/quadruped_pympc/controllers/gradient/lyapunov/centroidal_nmpc_lyapunov.py
@@ -3,7 +3,8 @@ import pathlib
 
 # Authors: Giulio Turrisi -
 
-from acados_template import AcadosOcp, AcadosOcpSolver, ACADOS_INFTY
+from acados_template import AcadosOcp, AcadosOcpSolver
+ACADOS_INFTY = 1000
 import numpy as np
 import scipy.linalg
 import casadi as cs

--- a/quadruped_pympc/controllers/gradient/nominal/centroidal_nmpc_gait_adaptive.py
+++ b/quadruped_pympc/controllers/gradient/nominal/centroidal_nmpc_gait_adaptive.py
@@ -9,7 +9,8 @@ import time
 import copy
 
 import casadi as cs
-from acados_template import AcadosOcp, AcadosOcpBatchSolver, ACADOS_INFTY
+from acados_template import AcadosOcp, AcadosOcpBatchSolver
+ACADOS_INFTY = 1000
 
 from quadruped_pympc import config
 from .centroidal_model_nominal import Centroidal_Model_Nominal

--- a/quadruped_pympc/controllers/gradient/nominal/centroidal_nmpc_nominal.py
+++ b/quadruped_pympc/controllers/gradient/nominal/centroidal_nmpc_nominal.py
@@ -3,7 +3,8 @@ import pathlib
 
 # Authors: Giulio Turrisi - 
 
-from acados_template import AcadosOcp, AcadosOcpSolver, ACADOS_INFTY
+from acados_template import AcadosOcp, AcadosOcpSolver
+ACADOS_INFTY = 1000
 from .centroidal_model_nominal import Centroidal_Model_Nominal
 import numpy as np
 import scipy.linalg

--- a/quadruped_pympc/interfaces/wb_interface.py
+++ b/quadruped_pympc/interfaces/wb_interface.py
@@ -450,10 +450,10 @@ class WBInterface:
             des_joints_pos.RR = np.array(temp[9:12]).reshape((3, ))
             
             
-            des_joints_vel.FL = (des_joints_pos.FL - qpos[legs_qpos_idx.FL])/simulation_dt
-            des_joints_vel.FR = (des_joints_pos.FR - qpos[legs_qpos_idx.FR])/simulation_dt
-            des_joints_vel.RL = (des_joints_pos.RL - qpos[legs_qpos_idx.RL])/simulation_dt
-            des_joints_vel.RR = (des_joints_pos.RR - qpos[legs_qpos_idx.RR])/simulation_dt
+            des_joints_vel.FL = (des_joints_pos.FL - qpos[legs_qpos_idx.FL])/self.contact_sequence_dts[0]
+            des_joints_vel.FR = (des_joints_pos.FR - qpos[legs_qpos_idx.FR])/self.contact_sequence_dts[0]
+            des_joints_vel.RL = (des_joints_pos.RL - qpos[legs_qpos_idx.RL])/self.contact_sequence_dts[0]
+            des_joints_vel.RR = (des_joints_pos.RR - qpos[legs_qpos_idx.RR])/self.contact_sequence_dts[0]
 
 
         else:
@@ -462,8 +462,8 @@ class WBInterface:
             des_joints_pos = nmpc_joints_vel
 
         # Saturate of desired joint positions and velocities
-        max_joints_pos_difference = 0.1
-        max_joints_vel_difference = 1.0
+        max_joints_pos_difference = 0.3
+        max_joints_vel_difference = 10.0
         
         # Calculate the difference
         actual_joints_pos = LegsAttr(*[qpos[legs_qpos_idx[leg_name]] for leg_name in self.legs_order])
@@ -480,7 +480,6 @@ class WBInterface:
             joints_vel_difference = des_joints_vel[leg] - actual_joints_vel[leg]
             saturated_joints_vel_difference = np.clip(joints_vel_difference, -max_joints_vel_difference, max_joints_vel_difference)
             des_joints_vel[leg] = actual_joints_vel[leg] + saturated_joints_vel_difference
-        
 
 
 

--- a/quadruped_pympc/interfaces/wb_interface.py
+++ b/quadruped_pympc/interfaces/wb_interface.py
@@ -466,10 +466,8 @@ class WBInterface:
         max_joints_vel_difference = 10.0
         
         # Calculate the difference
-        actual_joints_pos = LegsAttr(*[qpos[legs_qpos_idx[leg_name]] for leg_name in self.legs_order])
-        actual_joints_vel = LegsAttr(*[qvel[legs_qvel_idx[leg_name]] for leg_name in self.legs_order])
-        joints_pos_difference = des_joints_pos - actual_joints_pos
-        joints_vel_difference = des_joints_vel - actual_joints_vel
+        actual_joints_pos = LegsAttr(**{leg_name:qpos[legs_qpos_idx[leg_name]] for leg_name in self.legs_order})
+        actual_joints_vel = LegsAttr(**{leg_name:qvel[legs_qvel_idx[leg_name]] for leg_name in self.legs_order})
 
         # Saturate the difference for each leg
         for leg in ["FL", "FR", "RL", "RR"]:


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve the handling of constants and the calculation of joint velocities and positions in the quadruped controller.

### Constants Handling

* [`quadruped_pympc/controllers/gradient/collaborative/centroidal_nmpc_collaborative.py`](diffhunk://#diff-005eba72bd977945a6d3d9027545bc848321a27b85e1939f6e4d3ae5bf662caeL5-R6): Removed the import of `ACADOS_INFTY` from `acados_template` and defined it locally as `1000`.
* [`quadruped_pympc/controllers/gradient/input_rates/centroidal_nmpc_input_rates.py`](diffhunk://#diff-8fcb6957c06f6a844cc12de99330509c3cce1ff95f8063e9314960625ed9a526L12-R13): Removed the import of `ACADOS_INFTY` from `acados_template` and defined it locally as `1000`.
* [`quadruped_pympc/controllers/gradient/lyapunov/centroidal_nmpc_lyapunov.py`](diffhunk://#diff-68f950676b5f6b721f5fc7db7b5947d71ec9fa77cbe929f9af2b212bba9f8badL6-R7): Removed the import of `ACADOS_INFTY` from `acados_template` and defined it locally as `1000`.
* [`quadruped_pympc/controllers/gradient/nominal/centroidal_nmpc_gait_adaptive.py`](diffhunk://#diff-e0d9276c1e88af6db83c92c97996ffd674b297b217b2bfa86ff4ef9613ec649bL12-R13): Removed the import of `ACADOS_INFTY` from `acados_template` and defined it locally as `1000`.
* [`quadruped_pympc/controllers/gradient/nominal/centroidal_nmpc_nominal.py`](diffhunk://#diff-1fdeecdf2030679d9a96e5bd53459e380fdf1f28a448a9c74f04e836b178ca41L6-R7): Removed the import of `ACADOS_INFTY` from `acados_template` and defined it locally as `1000`.

### Joint Velocity and Position Calculation

* [`quadruped_pympc/interfaces/wb_interface.py`](diffhunk://#diff-249358717f5cfa728c2753966e98af80f9f9878924ea676d1380f45f6db2b0afL453-R456): Updated the calculation of desired joint velocities to use `self.contact_sequence_dts[0]` instead of `simulation_dt`.
* [`quadruped_pympc/interfaces/wb_interface.py`](diffhunk://#diff-249358717f5cfa728c2753966e98af80f9f9878924ea676d1380f45f6db2b0afL465-R470): Increased the saturation limits for desired joint positions and velocities to `0.3` and `10.0` respectively.
* [`quadruped_pympc/interfaces/wb_interface.py`](diffhunk://#diff-249358717f5cfa728c2753966e98af80f9f9878924ea676d1380f45f6db2b0afL465-R470): Refactored the calculation of `actual_joints_pos` and `actual_joints_vel` to use dictionary comprehensions for improved readability.
* [`quadruped_pympc/interfaces/wb_interface.py`](diffhunk://#diff-249358717f5cfa728c2753966e98af80f9f9878924ea676d1380f45f6db2b0afL486): Removed an unnecessary blank line at the end of the function.